### PR TITLE
chore(config): Refactor Terraform security checks, replace tfsec with trivy

### DIFF
--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -1,4 +1,4 @@
-# tfsec:ignore:aws-cloudfront-enable-waf
+# trivy:ignore:AVD-AWS-0011
 resource "aws_cloudfront_distribution" "this" {
   origin {
     domain_name              = aws_s3_bucket.web.bucket_regional_domain_name

--- a/s3.tf
+++ b/s3.tf
@@ -1,4 +1,4 @@
-# tfsec:ignore:aws-s3-enable-bucket-logging
+# trivy:ignore:AVD-AWS-0089
 resource "aws_s3_bucket" "logs" {
   bucket = var.logging_bucket_name
 }
@@ -49,7 +49,7 @@ resource "aws_s3_bucket_public_access_block" "logs" {
   restrict_public_buckets = true
 }
 
-# tfsec:ignore:aws-s3-encryption-customer-key
+# trivy:ignore:AVD-AWS-0132
 resource "aws_s3_bucket_server_side_encryption_configuration" "logs" {
   bucket = aws_s3_bucket.logs.id
 
@@ -98,7 +98,7 @@ resource "aws_s3_bucket_public_access_block" "web" {
   restrict_public_buckets = true
 }
 
-# tfsec:ignore:aws-s3-encryption-customer-key
+# trivy:ignore:AVD-AWS-0132
 resource "aws_s3_bucket_server_side_encryption_configuration" "web" {
   bucket = aws_s3_bucket.web.id
 


### PR DESCRIPTION
This update transitions our Terraform configurations' security ignore settings from tfsec to trivy. Key changes include:

- In cloudfront.tf, updating the ignore directive from tfsec:ignore:aws-cloudfront-enable-waf to trivy:ignore:AVD-AWS-0011.
- In s3.tf, changing the aws-s3-enable-bucket-logging ignore setting to trivy:ignore:AVD-AWS-0089.
- Altering the aws-s3-encryption-customer-key ignore in s3.tf to trivy:ignore:AVD-AWS-0132.