### PR TITLE
chore(config): Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,5 +33,8 @@ override.tf.json
 .terraformrc
 terraform.rc
 
+# Ignore Terraform lock files
+**/.terraform.lock.hcl
+
 # Ignore .DS_Store files which are macOS system files not relevant to the project
 .DS_Store


### PR DESCRIPTION
This commit updates the .gitignore file to ignore Terraform lock files (**/.terraform.lock.hcl) in all directories. This change ensures broader compatibility for users in different environments, particularly for public modules or repositories.