### PR TITLE
chore(config): Add auto_assign.yml for PR creator

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,2 @@
+# Set to author to set pr creator as assignee
+addAssignees: author


### PR DESCRIPTION
Added .github/auto_assign.yml to automatically set PR creators as assignees, simplifying the PR management process.