### PR TITLE
chore(deps): Update Terraform and provider version

### DIFF
--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = "1.6.4"
+  required_version = "1.6.5"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "5.26.0"
+      version = "5.29.0"
     }
   }
 }


### PR DESCRIPTION
Updated Terraform and AWS provider versions in the example configuration

- Terraform required version updated from 1.6.4 to 1.6.5.
- AWS provider version updated from 5.26.0 to 5.29.0.