### PR TITLE
refactor(valiables): update S3 and ACM naming

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -6,5 +6,5 @@ module "simple_website" {
   source              = "../../"
   domain_name         = local.domain_name
   logging_bucket_name = "${local.domain_name}-logs"
-  web_bucket_name     = "${local.domain_name}-web"
+  website_bucket_name = "${local.domain_name}-web"
 }

--- a/main.tf
+++ b/main.tf
@@ -8,14 +8,14 @@ module "logging_bucket" {
   source = "./modules/logging-bucket"
 
   logging_bucket_name = var.logging_bucket_name
-  web_bucket_name     = var.web_bucket_name
+  website_bucket_name = var.website_bucket_name
 }
 
 module "website_bucket" {
   source = "./modules/website-bucket"
 
   logging_bucket_name = var.logging_bucket_name
-  web_bucket_name     = var.web_bucket_name
+  website_bucket_name = var.website_bucket_name
 }
 
 module "cdn_distribution" {
@@ -25,8 +25,5 @@ module "cdn_distribution" {
   cloudfront_distribution_comment = var.cloudfront_distribution_comment
   domain_name                     = var.domain_name
   logging_bucket_name             = var.logging_bucket_name
-  web_bucket_name                 = var.web_bucket_name
-
-  #s3_bucket_web_regional_domain_name  = module.website_bucket.s3_bucket_regional_domain_name
-  #s3_bucket_logs_regional_domain_name = module.logging_bucket.s3_bucket_regional_domain_name
+  website_bucket_name             = var.website_bucket_name
 }

--- a/modules/cdn-distribution/main.tf
+++ b/modules/cdn-distribution/main.tf
@@ -17,7 +17,7 @@ data "aws_iam_policy_document" "this" {
     sid       = "AllowCloudFrontServicePrincipalReadOnly"
     effect    = "Allow"
     actions   = ["s3:GetObject"]
-    resources = ["arn:aws:s3:::${var.web_bucket_name}/*"]
+    resources = ["arn:aws:s3:::${var.website_bucket_name}/*"]
 
     principals {
       type        = "Service"
@@ -39,7 +39,7 @@ data "aws_route53_zone" "this" {
 
 locals {
   logging_bucket_domain_name = "${var.logging_bucket_name}.s3.amazonaws.com"
-  website_bucket_domain_name = "${var.web_bucket_name}.s3.amazonaws.com"
+  website_bucket_domain_name = "${var.website_bucket_name}.s3.amazonaws.com"
 }
 
 # trivy:ignore:AVD-AWS-0011
@@ -58,7 +58,6 @@ resource "aws_cloudfront_distribution" "this" {
   http_version        = "http2and3"
   is_ipv6_enabled     = true
   price_class         = "PriceClass_All"
-  #web_acl_id          = aws_wafv2_web_acl.this.arn
 
   custom_error_response {
     error_caching_min_ttl = 0
@@ -140,6 +139,6 @@ resource "aws_route53_record" "this" {
 }
 
 resource "aws_s3_bucket_policy" "this" {
-  bucket = var.web_bucket_name
+  bucket = var.website_bucket_name
   policy = data.aws_iam_policy_document.this.json
 }

--- a/modules/cdn-distribution/variables.tf
+++ b/modules/cdn-distribution/variables.tf
@@ -1,6 +1,11 @@
 variable "acm_certificate_arn" {
   type        = string
-  description = ""
+  description = "ARN of the ACM certificate."
+
+  validation {
+    condition     = can(regex("^arn:aws:acm:us-east-1:[0-9]{12}:certificate/[a-f0-9-]+$", var.acm_certificate_arn))
+    error_message = "The ACM certificate ARN is invalid."
+  }
 }
 
 variable "cloudfront_distribution_comment" {
@@ -64,42 +69,42 @@ variable "logging_bucket_name" {
   }
 }
 
-variable "web_bucket_name" {
+variable "website_bucket_name" {
   description = "Name of the S3 bucket for storing website content. Must be globally unique."
   type        = string
 
   validation {
-    condition     = length(var.web_bucket_name) >= 3 && length(var.web_bucket_name) <= 63
+    condition     = length(var.website_bucket_name) >= 3 && length(var.website_bucket_name) <= 63
     error_message = "Bucket names must be between 3 (min) and 63 (max) characters long."
   }
 
   validation {
-    condition     = can(regex("^[a-z0-9-.]+$", var.web_bucket_name))
+    condition     = can(regex("^[a-z0-9-.]+$", var.website_bucket_name))
     error_message = "Bucket names can consist only of lowercase letters, numbers, dots (.), and hyphens (-)."
   }
 
   validation {
-    condition     = can(regex("^[a-z0-9]", var.web_bucket_name)) && can(regex("[a-z0-9]$", var.web_bucket_name))
+    condition     = can(regex("^[a-z0-9]", var.website_bucket_name)) && can(regex("[a-z0-9]$", var.website_bucket_name))
     error_message = "Bucket names must begin and end with a letter or number."
   }
 
   validation {
-    condition     = !can(regex("[.]{2}", var.web_bucket_name))
+    condition     = !can(regex("[.]{2}", var.website_bucket_name))
     error_message = "Bucket names must not contain two adjacent periods."
   }
 
   validation {
-    condition     = !can(regex("^(\\d+\\.\\d+\\.\\d+\\.\\d+)$", var.web_bucket_name))
+    condition     = !can(regex("^(\\d+\\.\\d+\\.\\d+\\.\\d+)$", var.website_bucket_name))
     error_message = "Bucket names must not be formatted as an IP address."
   }
 
   validation {
-    condition     = !startswith(var.web_bucket_name, "xn--") && !startswith(var.web_bucket_name, "sthree-")
+    condition     = !startswith(var.website_bucket_name, "xn--") && !startswith(var.website_bucket_name, "sthree-")
     error_message = "Bucket names must not start with the prefix `xn--` and the prefix `sthree-`."
   }
 
   validation {
-    condition     = !endswith(var.web_bucket_name, "-s3alias") && !endswith(var.web_bucket_name, "--ol-s3")
+    condition     = !endswith(var.website_bucket_name, "-s3alias") && !endswith(var.website_bucket_name, "--ol-s3")
     error_message = "Bucket names must not end with the suffix `-s3alias` and the suffix `--ol-s3`."
   }
 }

--- a/modules/logging-bucket/main.tf
+++ b/modules/logging-bucket/main.tf
@@ -19,7 +19,7 @@ data "aws_iam_policy_document" "this" {
     condition {
       test     = "ArnLike"
       variable = "aws:SourceArn"
-      values   = ["arn:aws:s3:::${var.web_bucket_name}"]
+      values   = ["arn:aws:s3:::${var.website_bucket_name}"]
     }
 
     condition {

--- a/modules/logging-bucket/variables.tf
+++ b/modules/logging-bucket/variables.tf
@@ -38,42 +38,42 @@ variable "logging_bucket_name" {
   }
 }
 
-variable "web_bucket_name" {
+variable "website_bucket_name" {
   description = "Name of the S3 bucket for storing website content. Must be globally unique."
   type        = string
 
   validation {
-    condition     = length(var.web_bucket_name) >= 3 && length(var.web_bucket_name) <= 63
+    condition     = length(var.website_bucket_name) >= 3 && length(var.website_bucket_name) <= 63
     error_message = "Bucket names must be between 3 (min) and 63 (max) characters long."
   }
 
   validation {
-    condition     = can(regex("^[a-z0-9-.]+$", var.web_bucket_name))
+    condition     = can(regex("^[a-z0-9-.]+$", var.website_bucket_name))
     error_message = "Bucket names can consist only of lowercase letters, numbers, dots (.), and hyphens (-)."
   }
 
   validation {
-    condition     = can(regex("^[a-z0-9]", var.web_bucket_name)) && can(regex("[a-z0-9]$", var.web_bucket_name))
+    condition     = can(regex("^[a-z0-9]", var.website_bucket_name)) && can(regex("[a-z0-9]$", var.website_bucket_name))
     error_message = "Bucket names must begin and end with a letter or number."
   }
 
   validation {
-    condition     = !can(regex("[.]{2}", var.web_bucket_name))
+    condition     = !can(regex("[.]{2}", var.website_bucket_name))
     error_message = "Bucket names must not contain two adjacent periods."
   }
 
   validation {
-    condition     = !can(regex("^(\\d+\\.\\d+\\.\\d+\\.\\d+)$", var.web_bucket_name))
+    condition     = !can(regex("^(\\d+\\.\\d+\\.\\d+\\.\\d+)$", var.website_bucket_name))
     error_message = "Bucket names must not be formatted as an IP address."
   }
 
   validation {
-    condition     = !startswith(var.web_bucket_name, "xn--") && !startswith(var.web_bucket_name, "sthree-")
+    condition     = !startswith(var.website_bucket_name, "xn--") && !startswith(var.website_bucket_name, "sthree-")
     error_message = "Bucket names must not start with the prefix `xn--` and the prefix `sthree-`."
   }
 
   validation {
-    condition     = !endswith(var.web_bucket_name, "-s3alias") && !endswith(var.web_bucket_name, "--ol-s3")
+    condition     = !endswith(var.website_bucket_name, "-s3alias") && !endswith(var.website_bucket_name, "--ol-s3")
     error_message = "Bucket names must not end with the suffix `-s3alias` and the suffix `--ol-s3`."
   }
 }

--- a/modules/website-bucket/main.tf
+++ b/modules/website-bucket/main.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket" "this" {
-  bucket = var.web_bucket_name
+  bucket = var.website_bucket_name
 }
 
 resource "aws_s3_bucket_logging" "this" {

--- a/modules/website-bucket/variables.tf
+++ b/modules/website-bucket/variables.tf
@@ -38,42 +38,42 @@ variable "logging_bucket_name" {
   }
 }
 
-variable "web_bucket_name" {
+variable "website_bucket_name" {
   description = "Name of the S3 bucket for storing website content. Must be globally unique."
   type        = string
 
   validation {
-    condition     = length(var.web_bucket_name) >= 3 && length(var.web_bucket_name) <= 63
+    condition     = length(var.website_bucket_name) >= 3 && length(var.website_bucket_name) <= 63
     error_message = "Bucket names must be between 3 (min) and 63 (max) characters long."
   }
 
   validation {
-    condition     = can(regex("^[a-z0-9-.]+$", var.web_bucket_name))
+    condition     = can(regex("^[a-z0-9-.]+$", var.website_bucket_name))
     error_message = "Bucket names can consist only of lowercase letters, numbers, dots (.), and hyphens (-)."
   }
 
   validation {
-    condition     = can(regex("^[a-z0-9]", var.web_bucket_name)) && can(regex("[a-z0-9]$", var.web_bucket_name))
+    condition     = can(regex("^[a-z0-9]", var.website_bucket_name)) && can(regex("[a-z0-9]$", var.website_bucket_name))
     error_message = "Bucket names must begin and end with a letter or number."
   }
 
   validation {
-    condition     = !can(regex("[.]{2}", var.web_bucket_name))
+    condition     = !can(regex("[.]{2}", var.website_bucket_name))
     error_message = "Bucket names must not contain two adjacent periods."
   }
 
   validation {
-    condition     = !can(regex("^(\\d+\\.\\d+\\.\\d+\\.\\d+)$", var.web_bucket_name))
+    condition     = !can(regex("^(\\d+\\.\\d+\\.\\d+\\.\\d+)$", var.website_bucket_name))
     error_message = "Bucket names must not be formatted as an IP address."
   }
 
   validation {
-    condition     = !startswith(var.web_bucket_name, "xn--") && !startswith(var.web_bucket_name, "sthree-")
+    condition     = !startswith(var.website_bucket_name, "xn--") && !startswith(var.website_bucket_name, "sthree-")
     error_message = "Bucket names must not start with the prefix `xn--` and the prefix `sthree-`."
   }
 
   validation {
-    condition     = !endswith(var.web_bucket_name, "-s3alias") && !endswith(var.web_bucket_name, "--ol-s3")
+    condition     = !endswith(var.website_bucket_name, "-s3alias") && !endswith(var.website_bucket_name, "--ol-s3")
     error_message = "Bucket names must not end with the suffix `-s3alias` and the suffix `--ol-s3`."
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -59,42 +59,42 @@ variable "logging_bucket_name" {
   }
 }
 
-variable "web_bucket_name" {
+variable "website_bucket_name" {
   description = "Name of the S3 bucket for storing website content. Must be globally unique."
   type        = string
 
   validation {
-    condition     = length(var.web_bucket_name) >= 3 && length(var.web_bucket_name) <= 63
+    condition     = length(var.website_bucket_name) >= 3 && length(var.website_bucket_name) <= 63
     error_message = "Bucket names must be between 3 (min) and 63 (max) characters long."
   }
 
   validation {
-    condition     = can(regex("^[a-z0-9-.]+$", var.web_bucket_name))
+    condition     = can(regex("^[a-z0-9-.]+$", var.website_bucket_name))
     error_message = "Bucket names can consist only of lowercase letters, numbers, dots (.), and hyphens (-)."
   }
 
   validation {
-    condition     = can(regex("^[a-z0-9]", var.web_bucket_name)) && can(regex("[a-z0-9]$", var.web_bucket_name))
+    condition     = can(regex("^[a-z0-9]", var.website_bucket_name)) && can(regex("[a-z0-9]$", var.website_bucket_name))
     error_message = "Bucket names must begin and end with a letter or number."
   }
 
   validation {
-    condition     = !can(regex("[.]{2}", var.web_bucket_name))
+    condition     = !can(regex("[.]{2}", var.website_bucket_name))
     error_message = "Bucket names must not contain two adjacent periods."
   }
 
   validation {
-    condition     = !can(regex("^(\\d+\\.\\d+\\.\\d+\\.\\d+)$", var.web_bucket_name))
+    condition     = !can(regex("^(\\d+\\.\\d+\\.\\d+\\.\\d+)$", var.website_bucket_name))
     error_message = "Bucket names must not be formatted as an IP address."
   }
 
   validation {
-    condition     = !startswith(var.web_bucket_name, "xn--") && !startswith(var.web_bucket_name, "sthree-")
+    condition     = !startswith(var.website_bucket_name, "xn--") && !startswith(var.website_bucket_name, "sthree-")
     error_message = "Bucket names must not start with the prefix `xn--` and the prefix `sthree-`."
   }
 
   validation {
-    condition     = !endswith(var.web_bucket_name, "-s3alias") && !endswith(var.web_bucket_name, "--ol-s3")
+    condition     = !endswith(var.website_bucket_name, "-s3alias") && !endswith(var.website_bucket_name, "--ol-s3")
     error_message = "Bucket names must not end with the suffix `-s3alias` and the suffix `--ol-s3`."
   }
 }


### PR DESCRIPTION
Renamed `web_bucket_name` to `website_bucket_name` for better clarity.
Added validation for ACM certificate ARN to enforce correct format.
Removed outdated comments to clean up the code.
These changes improve code readability and configuration integrity.