### PR TITLE
fix(s3): disable uppercase in random string

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -55,4 +55,5 @@ module "website_cdn_distribution" {
 resource "random_string" "this" {
   length  = 8
   special = false
+  upper   = false
 }


### PR DESCRIPTION
Disable uppercase characters in random string generation for S3.