### PR TITLE
ci: update release configuration for chore commits

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -7,5 +7,11 @@
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
     "@semantic-release/github"
+  ],
+  "releaseRules": [
+    {
+      "type": "chore",
+      "release": "patch"
+    }
   ]
 }


### PR DESCRIPTION
Add release rule in .releaserc.json to create patch release for chore
type commits.