### PR TITLE
feat(s3): add optional S3 bucket name variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,10 @@ module "cloudfront_s3_website" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_domain_name"></a> [domain\_name](#input\_domain\_name) | The domain name to be managed by Route53. | `string` | n/a | yes |
+| <a name="input_domain_name"></a> [domain\_name](#input\_domain\_name) | The domain name to be managed by Route53. | `string` | `""` | no |
+| <a name="input_logging_bucket_name"></a> [logging\_bucket\_name](#input\_logging\_bucket\_name) | Name of the S3 bucket for storing logs. Must be globally unique. | `string` | `""` | no |
+| <a name="input_redirection_bucket_name"></a> [redirection\_bucket\_name](#input\_redirection\_bucket\_name) | Name of the S3 bucket for redirection. Must be globally unique. | `string` | `""` | no |
+| <a name="input_website_bucket_name"></a> [website\_bucket\_name](#input\_website\_bucket\_name) | Name of the S3 bucket for storing website content. Must be globally unique. | `string` | `""` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 locals {
-  logging_bucket_name     = "${var.domain_name}-logging-${random_string.this.result}"
-  redirection_bucket_name = "${var.domain_name}-redirection-${random_string.this.result}"
-  website_bucket_name     = "${var.domain_name}-website-${random_string.this.result}"
+  logging_bucket_name     = coalesce(var.logging_bucket_name, "${var.domain_name}-logging-${random_string.this.result}")
+  redirection_bucket_name = coalesce(var.redirection_bucket_name, "${var.domain_name}-redirection-${random_string.this.result}")
+  website_bucket_name     = coalesce(var.website_bucket_name, "${var.domain_name}-website-${random_string.this.result}")
 }
 
 module "domain_certificate" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,9 +1,28 @@
 variable "domain_name" {
   type        = string
   description = "The domain name to be managed by Route53."
+  default     = ""
 
   validation {
     condition     = can(regex("^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\\.[a-zA-Z0-9]([a-zA-Z0-9]{0,61}[a-zA-Z0-9])?)*(\\.[a-zA-Z]{2,})$", var.domain_name)) && length(var.domain_name) <= 255
     error_message = "The domain name is invalid."
   }
+}
+
+variable "logging_bucket_name" {
+  type        = string
+  description = "Name of the S3 bucket for storing logs. Must be globally unique."
+  default     = ""
+}
+
+variable "redirection_bucket_name" {
+  type        = string
+  description = "Name of the S3 bucket for redirection. Must be globally unique."
+  default     = ""
+}
+
+variable "website_bucket_name" {
+  type        = string
+  description = "Name of the S3 bucket for storing website content. Must be globally unique."
+  default     = ""
 }


### PR DESCRIPTION
Added new optional variables for S3 bucket names: logging_bucket_name,
redirection_bucket_name, and website_bucket_name. These variables allow
specifying custom names for the S3 buckets used for logging, redirection,
and website content. If these variables are not provided, default names
based on the domain_name and a random string will be used.